### PR TITLE
Add ghq installation

### DIFF
--- a/dot_local/share/chezmoi/run_once_setup.sh.tmpl
+++ b/dot_local/share/chezmoi/run_once_setup.sh.tmpl
@@ -22,6 +22,8 @@ main() {
 
   install_core_packages
   config_shell
+  install_go
+  install_ghq
   build_and_install_nvim
 }
 
@@ -63,6 +65,52 @@ install_eza() {
   silent_install_package eza
   {{ end -}}
   {{ end -}}
+}
+
+install_ghq() {
+  log "📦 Installing ghq..."
+  if command -v ghq >/dev/null 2>&1; then
+    logwarn "📦 ghq already installed, skipping..."
+    return
+  fi
+
+  {{ if eq .chezmoi.os "linux" -}}
+  {{ if eq .chezmoi.osRelease.id "debian" "ubuntu" -}}
+  if ! silent_install_package ghq; then
+    logwarn "ghq package not found, building from source..."
+    if ! command -v go >/dev/null 2>&1; then
+      install_go
+    fi
+    GO111MODULE=on go install github.com/x-motemen/ghq@latest >>"$LOGFILE" 2>&1
+    sudo install -m 755 "$HOME/go/bin/ghq" /usr/local/bin/ghq
+  fi
+  {{ end -}}
+  {{ end -}}
+
+  log "✅ ghq installed!"
+}
+
+install_go() {
+  GO_VERSION="1.24.4"
+  GO_ARCHIVE="go${GO_VERSION}.linux-amd64.tar.gz"
+
+  if command -v go >/dev/null 2>&1; then
+    current_version=$(go version | awk '{print $3}' | sed 's/go//')
+    if [ "$current_version" = "$GO_VERSION" ]; then
+      log "✅ Go $GO_VERSION already installed"
+      return
+    else
+      logwarn "🔄 Updating Go to $GO_VERSION (current: $current_version)"
+    fi
+  else
+    log "📥 Installing Go $GO_VERSION..."
+  fi
+
+  wget -q "https://go.dev/dl/$GO_ARCHIVE" -O "/tmp/$GO_ARCHIVE"
+  silent_run sudo rm -rf /usr/local/go
+  silent_run sudo tar -C /usr/local -xzf "/tmp/$GO_ARCHIVE"
+  rm -f "/tmp/$GO_ARCHIVE"
+  log "✅ Go installed to: /usr/local/go/bin/go"
 }
 
 build_and_install_nvim() {


### PR DESCRIPTION
## Summary
- install ghq in run_once setup
- restore call to install_go so go is available for ghq
- move ghq call outside of core packages

## Testing
- `bash -n dot_local/share/chezmoi/run_once_setup.sh.tmpl`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_684373c6ab7c832c96664a3ab0c11e78